### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file upload handling and DoS risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** External API wrapper functions (`fetch_pdb_data` and `run_blast_search`) lacked strict input sanitization, exposing potential SSRF or injection vulnerabilities via malicious parameters to third-party endpoints.
 **Learning:** This application wraps remote biological databases (NCBI BLAST and RCSB PDB) directly passing parameters to URLs and remote executors without validation. Without restricting inputs strictly to expected sets (e.g. alphanumeric IDs or valid sequence strings), untrusted input can manipulate endpoint calls.
 **Prevention:** Apply strict Regular Expression validations over inputs before integrating them into API calls.
+
+## 2024-05-24 - [Fix insecure file upload handling and DoS risk]
+**Vulnerability:** The `read_any` file upload function lacked validation on file sizes, file extensions, and allowed uploading of binary files parsed as CSV (bypassing Pandas type checks due to lack of a null byte check).
+**Learning:** External files read via pandas `read_csv` and `read_excel` functions need strict security checks to avoid excessive resource consumption (DoS) and potential arbitrary parsing of binaries as text.
+**Prevention:** Always enforce file extension whitelists, check max file size bounds against a reasonable limit (like 25MB), and validate that text-like formats like CSV are free of unexpected null bytes (`\x00`).

--- a/Proyecto_Agente/src/io_utils.py
+++ b/Proyecto_Agente/src/io_utils.py
@@ -13,6 +13,24 @@ import csv
 from typing import Optional
 
 
+# Límite de tamaño de archivo (25 MB)
+MAX_FILE_SIZE = 25 * 1024 * 1024
+
+
+def get_file_size(file) -> int:
+    """Obtiene el tamaño del archivo en bytes."""
+    if hasattr(file, "size"):
+        # Objetos de Streamlit (UploadedFile)
+        return file.size
+
+    # Objetos file-like estándar (buscando hasta el final)
+    current_pos = file.tell()
+    file.seek(0, 2)  # Mover al final
+    size = file.tell()
+    file.seek(current_pos)  # Restaurar posición original
+    return size
+
+
 def read_any(file) -> Optional[pd.DataFrame]:
     """
     Lee archivos de datos en múltiples formatos (CSV, XLS, XLSX) con detección automática.
@@ -38,20 +56,36 @@ def read_any(file) -> Optional[pd.DataFrame]:
     if file is None:
         return None
 
-    # Obtener nombre del archivo en minúsculas para comparación
+    # Validación de seguridad: Validar extensiones de archivo permitidas
     name = file.name.lower()
+    allowed_extensions = [".csv", ".xls", ".xlsx"]
+    if not any(name.endswith(ext) for ext in allowed_extensions):
+        raise ValueError("Error de seguridad: Extensión de archivo no permitida. Solo se aceptan .csv, .xls, .xlsx")
+
+    # Validación de seguridad: Prevenir DoS por archivos enormes
+    file_size = get_file_size(file)
+    if file_size > MAX_FILE_SIZE:
+        raise ValueError(f"Error de seguridad: El archivo excede el tamaño máximo permitido de 25MB.")
 
     # ============================================================
     # Procesamiento de archivos CSV
     # ============================================================
     if name.endswith(".csv"):
         try:
+            # Validación de seguridad: Check por bytes nulos (indicador de archivo binario camuflado)
+            raw_bytes = file.read(4096)
+            if b'\x00' in raw_bytes:
+                 raise ValueError("Error de seguridad: Se detectaron bytes nulos en el archivo CSV. Posible archivo binario malicioso.")
+
             # Leer una muestra del archivo para detectar el delimitador
             # Esto es útil para manejar tanto CSV separados por coma como por punto y coma
-            raw = file.read(4096).decode(errors="ignore")
+            raw = raw_bytes.decode(errors="ignore")
             dialect = csv.Sniffer().sniff(raw)
             delim = dialect.delimiter
 
+        except ValueError as ve:
+            # Re-lanzar excepciones de seguridad
+            raise ve
         except Exception:
             # Si falla la detección, usar coma por defecto
             delim = ","


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The file upload handler `read_any()` previously accepted all incoming file streams without verifying content type size bounds, or payload extensions, leaving the application vulnerable to DoS attacks through maliciously sized files and parser exploits using binary payloads.
🎯 Impact: An attacker could perform denial of service through memory exhaustion (large files) or trigger parser side-effects by submitting binary code.
🔧 Fix: Added strict `.csv`, `.xls`, `.xlsx` file extension validation, implemented a max length check of 25MB, and placed a chunk-read inspection for null-bytes to instantly drop malformed binary disguised files.
✅ Verification: Ensure the application no longer allows binary files via CSV upload forms, rejects non-spreadsheet extensions, and terminates file processing early if the file exceeds the 25MB threshold.

---
*PR created automatically by Jules for task [513013177591674999](https://jules.google.com/task/513013177591674999) started by @Vagarh*